### PR TITLE
Fix typo (threading.Lock)

### DIFF
--- a/src/CPCargo/uploaders.py
+++ b/src/CPCargo/uploaders.py
@@ -40,7 +40,7 @@ class CompletionWaiter:
   def __init__(self, timeout=30) -> None:
     self._timeout = timeout
     self.active_files = set()
-    self._lock = threading.lock()
+    self._lock = threading.Lock()
 
   def get_callback(self, filename):
     with self._lock:


### PR DESCRIPTION
Thanks for a great library!

I encountered the following error, and this PR aims to solve the issue.

```
Traceback (most recent call last):
  File ".../lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File ".../lib/python3.8/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File ".../lib/python3.8/site-packages/CPCargo/cpcargo.py", line 78, in watcher
    agent = Watcher(src_dir=src,
  File ".../lib/python3.8/site-packages/CPCargo/cpcargo.py", line 42, in __init__
    self._waiter = CompletionWaiter()
  File ".../lib/python3.8/site-packages/CPCargo/uploaders.py", line 43, in __init__
    self._lock = threading.lock()
AttributeError: module 'threading' has no attribute 'lock'
```