### PR TITLE
Pass the waiter to S3Uploader

### DIFF
--- a/src/CPCargo/cpcargo.py
+++ b/src/CPCargo/cpcargo.py
@@ -43,6 +43,7 @@ class Watcher():
     self._uploader = S3Uploader(region=region,
                                 src_prefix=src_dir,
                                 dst_url=dst_url,
+                                waiter=self._waiter,
                                 pool_size=0)
     self._handler = CheckpointHandler(uploader=self._uploader,
                                       file_regex=self._file_re,


### PR DESCRIPTION
The S3Uploader was recently changed to require a waiter, but none is provided when it's instantiated, causing an exception. This passes the waiter in.