### PR TITLE
Add expected waiter param to Watcher's S3Uploader initialization

### DIFF
--- a/src/CPCargo/cpcargo.py
+++ b/src/CPCargo/cpcargo.py
@@ -43,7 +43,8 @@ class Watcher():
     self._uploader = S3Uploader(region=region,
                                 src_prefix=src_dir,
                                 dst_url=dst_url,
-                                pool_size=0)
+                                waiter=self._waiter,
+                                pool_size=0)    
     self._handler = CheckpointHandler(uploader=self._uploader,
                                       file_regex=self._file_re,
                                       recursive=self._recursive)


### PR DESCRIPTION
Upon attempting to run test/example.py, I encountered an error: It expected waiter as a positional param and it wasn't found.
This change resolved it.

It appears that the expected waiter param in S3Uploader's `__init__` was added about a month ago in this commit: https://github.com/samikama/CPCargo/commit/9881114792e0789696491367d11184fef7d91a6a